### PR TITLE
Board wide new thread limit

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -2643,6 +2643,20 @@ function diceRoller($post) {
 	}
 }
 
+function max_posts_per_hour($post) {
+	global $config, $board;
+	if (!$config['hour_max_threads']) return false;
+
+	if ($post['op']) {
+		$query = prepare(sprintf('SELECT COUNT(*) AS `count` FROM ``posts_%s`` WHERE `thread` IS NULL AND FROM_UNIXTIME(`time`) > DATE_SUB(NOW(), INTERVAL 1 HOUR);', $board['uri']));
+		$query->bindValue(':ip', $_SERVER['REMOTE_ADDR'], PDO::PARAM_STR);
+		$query->execute() or error(db_error($query));
+		$r = $query->fetch(PDO::FETCH_ASSOC);
+
+		return ($r['count'] >= $config['hour_max_threads']);
+	}
+}
+
 function slugify($post) {
 	global $config;
 


### PR DESCRIPTION
Put this in the instance-config.php in order to use it.

```
$config['hour_max_threads'] = 30;

$config['filters'][] = array(
		'condition' => array(
			'custom' => 'max_posts_per_hour'
		),
		'action' => 'reject',
		'message' => 'On this board, to prevent raids the number of threads that can be created per hour is limited. Please try again later, or post in an existing thread.'
	);
```