### PR TITLE
If a user is using a transparent proxy, do not allow them to post if …

### DIFF
--- a/inc/instance-config.php
+++ b/inc/instance-config.php
@@ -20,4 +20,6 @@
 	//$config['root']				= '/';
 	
 	
+$config['proxy_check'] = true; // If user is using a transparent proxy, see if their actual IP is banned. If it is banned, don't let them post.
+
 ?>


### PR DESCRIPTION
…their original IP address happens to be banned.