### PR TITLE
Fix "File deleted" 404

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -832,9 +832,9 @@
 	// Location of above images.
 	$config['file_thumb'] = 'static/%s';
 	// Location of thumbnail to use for spoiler images.
-	$config['spoiler_image'] = 'static/spoiler.png';
+	$config['spoiler_image'] = '/static/spoiler.png';
 	// Location of thumbnail to use for deleted images.
-	$config['image_deleted'] = 'static/deleted.png';
+	$config['image_deleted'] = '/static/deleted.png';
 
 	// When a thumbnailed image is going to be the same (in dimension), just copy the entire file and use
 	// that as a thumbnail instead of resizing/redrawing.

--- a/templates/post/image.html
+++ b/templates/post/image.html
@@ -34,7 +34,7 @@
 						{{ config.file_thumb|sprintf(config.file_icons.default) }}
 					{% endif %}
 				{% elseif post.thumb == 'spoiler' %}
-					{{ config.root }}{{ config.spoiler_image }}
+					{{ config.spoiler_image }}
 				{% else %}
 					{{ config.uri_thumb }}{{ post.thumb }}
 				{% endif %}


### PR DESCRIPTION
This commit fixes the "image deleted" link being 404.

Make sure to also change the spoiler_image setting in instance-config to this
`$config['spoiler_image'] = '/static/spoilers/rotate.php';`