### PR TITLE
Remove the notice about IP addresses from the banning and warning templates.

### DIFF
--- a/templates/banned.html
+++ b/templates/banned.html
@@ -83,7 +83,7 @@
 		{% endif %}
 		</span>
 	</p>
-	<p>{% trans %}Your IP address is{% endtrans %} <strong>{{ ban.ip }}</strong>.</p>
+	<p><strong>{% trans %}Your IP address is not stored on mlpol.net. We currently hash IP addresses{% endtrans %}</strong>.</p>
 
 	{% if config.ban_page_extra %}
 		<p>{{ config.ban_page_extra }}</p>

--- a/templates/warning.html
+++ b/templates/warning.html
@@ -1,7 +1,7 @@
 {% filter remove_whitespace %}
 {# Automatically removes unnecessary whitespace #}
 <div class="ban">
-	<h2>{% trans %}You were issued an warning!{% endtrans %}</h2>
+	<h2>{% trans %}You were issued an warning! ;_;{% endtrans %}</h2>
 	{% if warning.reason %}
 		<p>
 			{% trans %}for the following reason:{% endtrans %}
@@ -21,7 +21,7 @@
 				{% endif %}
 			{% endif %}
 	</p>
-	<p>{% trans %}Your IP address is{% endtrans %} <strong>{{ warning.ip }}</strong>.</p>
+	<p><strong>{% trans %}Your IP address is not stored on mlpol.net. We currently hash IP addresses { % endtrans % }</strong>.</p>
 
 	{% if config.warning_page_extra %}
 		<p>{{ config.warning_page_extra }}</p>


### PR DESCRIPTION
Still need to figure out how they're generated. According to @fallenPineapple they aren't being stored on the database.