### PR TITLE
Fix CSS in HASH_IP_TABLE_UPDATES_SCRIPT.php

### DIFF
--- a/HASH_IP_TABLE_UPDATES_SCRIPT.php
+++ b/HASH_IP_TABLE_UPDATES_SCRIPT.php
@@ -167,3 +167,5 @@ switch($step)
 echo Element('page.html', $page);
 
 ?>
+<!-- There is probably a much better way to do this, but eh. -->
+<link rel="stylesheet" type="text/css" href="stylesheets/style.css" />


### PR DESCRIPTION
CSS is now displayed in the script. Previously, the page did not have a stylesheet associated with it.