### PR TITLE
Update and BugFix to Ban code

### DIFF
--- a/inc/bans.php
+++ b/inc/bans.php
@@ -130,16 +130,34 @@ class Bans {
 	static public function find($ip, $board = false, $get_mod_info = false, $hashed_ip = false) {
 		global $config;
 		
+		// Build string for array of boards to check for bans on
+		$board_string = '(`board` IS NULL OR `board` = :board) AND';
+		if($board !== false && is_array($board)){
+			$board_string = '(';
+			for($i=0; $i<count($board); $i++)
+				$board_string .= '`board` = :board_' . (int)$i . ' OR ';
+			$board_string = substr($board_string, 0, -4);
+			$board_string .= ') AND';
+		}
+
 		$query = prepare('SELECT ``bans``.*' . ($get_mod_info ? ', `username`' : '') . ' FROM ``bans``
 			' . ($get_mod_info ? 'LEFT JOIN ``mods`` ON ``mods``.`id` = `creator`' : '') . '
 			WHERE
-			(' . ($board !== false ? '(`board` IS NULL OR `board` = :board) AND' : '') . '
+			(' . ($board !== false ? $board_string : '') . '
 			' . ($config['bcrypt_ip_addresses'] ? '(`ipstart` = :ip))' : '(`ipstart` = :ip OR (:ip >= `ipstart` AND :ip <= `ipend`)))') . ' 
 			ORDER BY `expires` IS NULL, `expires` DESC');
 		
-		if ($board !== false)
-			$query->bindValue(':board', $board, PDO::PARAM_STR);
-		
+		if ($board !== false){
+			if(is_array($board))
+			{
+				// Build bind to query array of boards to check for bans on
+				for($i=0; $i<count($board); $i++)
+					$query->bindValue(':board_' . (int)$i, $board[$i], PDO::PARAM_STR);
+			} else {
+				$query->bindValue(':board', $board, PDO::PARAM_STR);
+			}
+		}
+
 		$query->bindValue(':ip', $config['bcrypt_ip_addresses'] ? ($hashed_ip?$ip:get_ip_hash($ip)) : inet_pton($ip));
 		$query->execute() or error(db_error($query));
 		

--- a/inc/bans.php
+++ b/inc/bans.php
@@ -127,7 +127,7 @@ class Bans {
 		return array($ipstart, $ipend);
 	}
 	
-	static public function find($ip, $board = false, $get_mod_info = false) {
+	static public function find($ip, $board = false, $get_mod_info = false, $hashed_ip = false) {
 		global $config;
 		
 		$query = prepare('SELECT ``bans``.*' . ($get_mod_info ? ', `username`' : '') . ' FROM ``bans``
@@ -140,7 +140,7 @@ class Bans {
 		if ($board !== false)
 			$query->bindValue(':board', $board, PDO::PARAM_STR);
 		
-		$query->bindValue(':ip', $config['bcrypt_ip_addresses'] ? get_ip_hash($ip) : inet_pton($ip));
+		$query->bindValue(':ip', $config['bcrypt_ip_addresses'] ? ($hashed_ip?$ip:get_ip_hash($ip)) : inet_pton($ip));
 		$query->execute() or error(db_error($query));
 		
 		$ban_list = array();
@@ -340,7 +340,7 @@ class Bans {
 	}
 	
 	static public function delete($ban_id, $modlog = false, $boards = false, $dont_rebuild = false) {
-		global $config;
+		global $config, $mod;
 
 		if ($boards && $boards[0] == '*') $boards = false;
 
@@ -352,7 +352,7 @@ class Bans {
 			}
 
 			if ($boards !== false && !in_array($ban['board'], $boards))
-		                error($config['error']['noaccess']);
+		        error($config['error']['noaccess']);
 			
 			$mask = self::range_to_string(array($ban['ipstart'], $ban['ipend']));
 			

--- a/inc/config.php
+++ b/inc/config.php
@@ -1640,7 +1640,7 @@ $config['nicenotice_reasons'][] = "We care, and we hope you feel better soon. We
 
 	/* Post Controls */					
     // View IP addresses
-    $config['mod']['show_ip'] = DEVELOPER;
+    $config['mod']['show_ip'] = DEVELOPER;	
     // Delete a post
     $config['mod']['delete'] = MOD;
     // Deliver Bantz to User and Post
@@ -1656,10 +1656,14 @@ $config['nicenotice_reasons'][] = "We care, and we hope you feel better soon. We
     $config['mod']['warning'] = JANITOR;
     // Ban a user for a post
     $config['mod']['ban'] = MOD;
+    // Ban a user for a post on all boards even if mod isnt moderator of all boards
+    $config['mod']['ban_all_boards'] = MOD;
     // Ban and delete (one click; instant)
     $config['mod']['bandelete'] = MOD;
     // Remove bans
     $config['mod']['unban'] = JANITOR;
+    // Remove a Ban on all boards even if mod isnt moderator of all boards
+    $config['mod']['unban_all_boards'] = JANITOR;
     // Spoiler image
     $config['mod']['spoilerimage'] = MOD;
 	// Ban cookies for posting
@@ -1737,7 +1741,7 @@ $config['nicenotice_reasons'][] = "We care, and we hope you feel better soon. We
 	// Show expired bans in the ban list (they are kept in cache until the culprit returns)
 	$config['mod']['view_banexpired'] = true;
 	// View ban for IP address
-	$config['mod']['view_ban'] = $config['mod']['view_banlist'];
+	$config['mod']['view_ban'] = $config['mod']['unban'];
 	// View IP address notes
 	$config['mod']['view_notes'] = JANITOR;
 	// Create notes
@@ -1804,7 +1808,7 @@ $config['nicenotice_reasons'][] = "We care, and we hope you feel better soon. We
 	$config['mod']['edit_config'] = ADMIN;
 	// View ban appeals
 	$config['mod']['view_ban_appeals'] = MOD;
-	// Accept and deny ban appeals
+	// Accept and deny ban appeals (this will be valid for all borads regardless of mod board setting)
 	$config['mod']['ban_appeals'] = MOD;
 	// View the recent posts page
 	$config['mod']['recent'] = MOD;

--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -956,7 +956,10 @@ function mod_page_ip($ip) {
 	$args['token'] = make_secure_link_token('ban');
 	
 	if (hasPermission($config['mod']['view_ban'])) {
-		$args['bans'] = Bans::find($ip, false, true, true);
+		if(hasPermission($config['mod']['unban_all_boards']))
+			$args['bans'] = Bans::find($ip, false, true, true);
+		else
+			$args['bans'] = Bans::find($ip, $mod['boards'], true, true);
 	}
 	
 	if (hasPermission($config['mod']['view_notes'])) {

--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -866,7 +866,10 @@ function mod_page_ip($ip) {
 		if (!hasPermission($config['mod']['unban']))
 			error($config['error']['noaccess']);
 		
-		Bans::delete($_POST['ban_id'], true, $mod['boards']);
+		if(hasPermission($config['mod']['unban_all_boards']))
+			Bans::delete($_POST['ban_id'], true, false);
+		else
+			Bans::delete($_POST['ban_id'], true, $mod['boards']);
 		
 		header('Location: ?/IP/' . $ip . '#bans', true, $config['redirect_http']);
 		return;
@@ -953,7 +956,7 @@ function mod_page_ip($ip) {
 	$args['token'] = make_secure_link_token('ban');
 	
 	if (hasPermission($config['mod']['view_ban'])) {
-		$args['bans'] = Bans::find($ip, false, true);
+		$args['bans'] = Bans::find($ip, false, true, true);
 	}
 	
 	if (hasPermission($config['mod']['view_notes'])) {
@@ -1247,6 +1250,9 @@ function mod_ban() {
 	}
 	
 	require_once 'inc/mod/ban.php';
+
+	if ($_POST['board'] == '*' && !hasPermission($config['mod']['ban_all_boards']))
+		error($config['error']['noaccess']);
 	
 	Bans::new_ban($_POST['ip'], $_POST['uuser_cookie'], $_POST['reason'], $_POST['ban_length'], $_POST['board'] == '*' ? false : $_POST['board']);
 
@@ -1276,7 +1282,10 @@ function mod_bans() {
 			error(sprintf($config['error']['toomanyunban'], $config['mod']['unban_limit'], count($unban)));
 		
 		foreach ($unban as $id) {
-			Bans::delete($id, true, $mod['boards'], true);
+			if(hasPermission($config['mod']['unban_all_boards']))
+				Bans::delete($_POST['ban_id'], true, false, true);
+			else
+				Bans::delete($_POST['ban_id'], true, $mod['boards'], true);
 		}
                 rebuildThemes('bans');
 		header('Location: ?/bans', true, $config['redirect_http']);
@@ -2019,7 +2028,7 @@ function mod_delete($board, $post) {
 	
 	if (!hasPermission($config['mod']['delete'], $board))
 		error($config['error']['noaccess']);
-	
+
 	// Delete post (get thread id)
 	$thread_id = deletePost($post);
 	// Record the action

--- a/templates/mod/ban_form.html
+++ b/templates/mod/ban_form.html
@@ -90,12 +90,14 @@ $(window).load(function(){
 			<th>{% trans 'Board' %}</th>
 			<td>
 				<ul style="list-style:none;padding:2px 5px">
-					<li>
-						<input type="radio" name="board" value="*" id="ban-allboards" checked> 
-						<label style="display:inline" for="ban-allboards">
-							<em>{% trans 'all boards' %}</em>
-						</label>
-					</li>
+					{% if mod|hasPermission(config.mod.ban_all_boards) %}
+						<li>
+							<input type="radio" name="board" value="*" id="ban-allboards" checked> 
+							<label style="display:inline" for="ban-allboards">
+								<em>{% trans 'all boards' %}</em>
+							</label>
+						</li>
+					{% endif %}
 					
 					{% for board in boards %}
 						<li>


### PR DESCRIPTION
Fixed code so mods can see bans assigned to IP when viewing IP details
Added setting so you can allow mod group to unban/ban on whole board even if mod isn't assigned a role on all boards.
Fixed code so mods only see bans on boards they moderate (unless allowed to unban on all boards)
Changed the level needed to view bans on IP details to 'unban' level.
