### PR TITLE
Bugfix: D+ and D++

### DIFF
--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -2174,7 +2174,7 @@ function mod_deletebyip($boardName, $post, $global = false) {
 	$query = preg_replace('/UNION ALL $/', '', $query);
 	
 	$query = prepare($query);
-	$query->bindValue(':ip', $config['bcrypt_ip_addresses'] ? get_ip_hash($ip) : $ip);
+	$query->bindValue(':ip', $ip);
 	$query->execute() or error(db_error($query));
 	
 	if ($query->rowCount() < 1)


### PR DESCRIPTION
Previously, if IP hashing was enabled, the D+ and D++ deletion features would not work. This fixes that issue.

Credit: PupperWoff