### PR TITLE
Remove config link from the dash; it has been disabled and is thus useless

### DIFF
--- a/templates/mod/dashboard.html
+++ b/templates/mod/dashboard.html
@@ -121,9 +121,6 @@
 		{% if mod|hasPermission(config.mod.rebuild) %}
 			<li><a href="?/rebuild">{% trans 'Rebuild' %}</a></li>
 		{% endif %}
-		{% if mod|hasPermission(config.mod.edit_config) %}
-			<li><a href="?/config">{% trans 'Configuration' %}</a></li>
-		{% endif %}
 		
 	</ul>
 </fieldset>


### PR DESCRIPTION
Note to self: May want to work on removing code related to the config editor entirely. It's not needed anymore, and it is bloat.