### PR TITLE
Bugfix to Bug #129 - Public Announcement List Page (js)

### DIFF
--- a/js/mod/announcements-list.js
+++ b/js/mod/announcements-list.js
@@ -1,7 +1,7 @@
 var announcementlist_init = function(token, inMod) {
   inMod = !inMod;
 
-  $.getJSON(inMod ? ("?/announcements.json/"+token) : ("/" + token), function(json) {
+  $.getJSON(inMod ? ("?/announcements.json/"+token) : (token), function(json) {
     var tr;
 
     var thead = $("<thead/>");


### PR DESCRIPTION
After this update (new javascript file) all you have to do is do an hard reload  Ctrl + F5 (the the cached js is updated in browser) and the full announcement list will be shown